### PR TITLE
Canonicalize rotation when testing flattening

### DIFF
--- a/tests/parameterization/test.js
+++ b/tests/parameterization/test.js
@@ -60,8 +60,17 @@ describe("SpectralConformalParameterization", function() {
 			let success = true;
 			let flattening_sol = loadFlattening();
 			let flattening = spectralConformalParameterization.flatten();
+
+			let v0 = mesh.vertices[0];
+			let p0 = new Complex(flattening[v0].x, flattening[v0].y);
+			let s0 = new Complex(flattening_sol[v0].x, flattening_sol[v0].y);
+			let rot = s0.overComplex(p0);
+
 			for (let v of mesh.vertices) {
-				if (!flattening[v].isValid() || flattening_sol[v].minus(flattening[v]).norm() > 1e-6) {
+				let p = new Complex(flattening[v].x, flattening[v].y);
+				let pRot = p.timesComplex(rot);
+				let flatteningRot = new Vector(pRot.re, pRot.im, flattening[v].z);
+				if (!flatteningRot.isValid() || flattening_sol[v].minus(flatteningRot).norm() > 1e-6) {
 					success = false;
 					break;
 				}


### PR DESCRIPTION
The [corresponding C++ tests](https://github.com/GeometryCollective/ddg-exercises/blob/40ff1b75e3bc9fb0603fcbb9e8de1ee22aa3bc65/projects/parameterization/src/test-param.cpp#L122-L136) for `SpectralConformalParameterization.flatten` check if there exists a valid rotation between the produced flattening and the reference solution, but it seems like this logic might be missing from the tests here (note that the `normalize` function in `geometry.js` centers and rescales the points, but does not canonicalize rotation). This PR ports over the rotation logic from the C++ test. 

(The motivation is that my code for https://brickisland.net/ddg-web/assignments/assignment4/index.html would only pass the test with this adjustment. But it's possible that I just missed some instruction that would allow me to pass the original test, e.g. perhaps there is some preferred rotation specified in the assignment spec that I did not notice.)